### PR TITLE
Float stations are now parsed correctly.

### DIFF
--- a/LINZ/Geodetic/Adjustment.py
+++ b/LINZ/Geodetic/Adjustment.py
@@ -581,7 +581,7 @@ class Adjustment(object):
                 hfloat = float(hfs)
                 vfloat = float(vfs)
                 self.options.floatStations.extend(
-                    (((hfloat, vfloat), v) for v in self._splitStationList(value))
+                    (((hfloat, vfloat), v) for v in self._splitStationList(slist))
                 )
             except:
                 raise RuntimeError("Invalid float option: " + value)


### PR DESCRIPTION
The entire string was being treated as a list of stations, including the `hfloat` and `vfloat` values. So this:
```adj.setConfig("float", "10.0 91.0 ST1")```

Was being parsed as three stations "10.0", "91.0", and "ST1" each with an `hfloat` and `vfloat` value of 10.0 and 91.0 respectively.

This fixes this bug by passing the `slist` value into `_splitStationList` rather than `value`.